### PR TITLE
Handle updates above 0.9.4

### DIFF
--- a/PMS_Updater.sh
+++ b/PMS_Updater.sh
@@ -144,7 +144,7 @@ findLatest()
 
     webGet "$URL" || exit $?
         echo Searching $URL for $PMSPATTERN ..... | LogMsg -n
-    DOWNLOADURL=`grep -o "http[s]:.*$PMSPATTERN" "$DOWNLOADPATH/$SCRAPEFILE"`
+    DOWNLOADURL=`grep -o "http[s]*:.*$PMSPATTERN" "$DOWNLOADPATH/$SCRAPEFILE"`
     if [ "x$DOWNLOADURL" = "x" ]; then {
         # DOWNLOADURL is zero length, i.e. nothing matched PMSPATTERN. Error and exit
         echo Could not find a $PMSPATTERN download link on page $URL | LogMsg -f
@@ -189,8 +189,10 @@ applyUpdate()
     } else {
         echo Done. | LogMsg -f
     } fi
+    ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/Plex\ Media\ Server $PMSPARENTPATH/$PMSLIVEFOLDER/Plex_Media_Server 2>&1 | LogMsg           
+    ln -s $PMSPARENTPATH/$PMSLIVEFOLDER/libpython2.7.so.1 $PMSPARENTPATH/$PMSLIVEFOLDER/libpython2.7.so 2>&1 | LogMsg
     echo Starting Plex Media Server .....| LogMsg -n
-    service plexmediaserver start 2>&1 | LogMsg
+    service plexmediaserver start
     echo Done. | LogMsg -f
 }
 


### PR DESCRIPTION
-Corrected matching http or https for download link
-recreate soft links in downloaded folder
-capturing the output of service plexmedia start with LogMsg was causing script to hang so LogMsg has been removed on this line for now.
